### PR TITLE
bug in getting overview pages from multiple matches patched

### DIFF
--- a/glassdoor/gd.py
+++ b/glassdoor/gd.py
@@ -3,9 +3,10 @@
 """
     glassdoor
     ~~~~~~~~~
-    Glassdoor unofficial API
+    Glassdoor unofficial API v1.1
 
     :copyright: (c) 2012 by Hackerlist, Inc
+    :improved by Kevin Wang
     :license: BSD, see LICENSE for more details.
 """
 
@@ -29,7 +30,12 @@ def get(company='', company_slug=''):
         url= '%s/%s' % (GLASSDOOR_API, company_slug)
     r = requests.get(url)
     soup = BeautifulSoup(r.content)
-    return parse(soup)
+    results = parse(soup)
+    if 'suggestions' in results: 
+        for s in results['suggestions']:
+            if company.lower() in s[0].lower():
+                return get(company_slug=s[1])
+    return results
 
 def parse_meta(soup):
     data = {'website': '',


### PR DESCRIPTION
Before when running a query for 'google'
![before_cmd_line](https://f.cloud.github.com/assets/883296/2301298/a43df0ea-a139-11e3-8634-4480267f89e3.png)
After updates to gd.py
![after_cmd_line](https://f.cloud.github.com/assets/883296/2301296/a43d5504-a139-11e3-97a0-5f3393fad551.png)

Before in ipython
![before_ipython](https://f.cloud.github.com/assets/883296/2301297/a43de5d2-a139-11e3-91a9-7bbb7dd3f97a.png)
after updates to gd.py
![after_ipython](https://f.cloud.github.com/assets/883296/2301299/a43e7916-a139-11e3-8bad-fd27aed486e6.png)
